### PR TITLE
fix #524 empty BOM file on KiCad 7

### DIFF
--- a/fabrication.py
+++ b/fabrication.py
@@ -313,7 +313,7 @@ class Fabrication:
                 components = part["refs"].split(",")
                 for component in components:
                     for fp in self.board.Footprints():
-                        if fp.GetReference() == component and fp.IsDNP():
+                        if fp.GetReference() == component and hasattr(fp, 'IsDNP') and callable(fp.IsDNP) and fp.IsDNP():
                             components.remove(component)
                             part["refs"] = ",".join(components)
                             self.logger.info(


### PR DESCRIPTION
Possible fix for empty BOM file on KiCad 7 https://github.com/Bouni/kicad-jlcpcb-tools/issues/524
Explained here: https://github.com/Bouni/kicad-jlcpcb-tools/issues/535#issuecomment-2360655030